### PR TITLE
Lint only with Node 15

### DIFF
--- a/.github/workflows/node-ci-lint.yml
+++ b/.github/workflows/node-ci-lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [15.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
###  Summary

Linting isn't really a version thing, so stick to linting with just one version, to save on CO2 - No seriously, it'll save CO2 and that's good thing ;)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/tasks-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
