### PR TITLE
App Home new user bug

### DIFF
--- a/nodejs/listeners/events/app_home_opened.js
+++ b/nodejs/listeners/events/app_home_opened.js
@@ -3,7 +3,13 @@ const { reloadAppHome } = require('../../utilities');
 module.exports = (app) => {
   app.event('app_home_opened', async ({ client, event, body }) => {
     try {
-      await reloadAppHome(client, event.user, body.team_id, event.view.private_metadata);
+      if (event.view) {
+        await reloadAppHome(client, event.user, body.team_id, event.view.private_metadata);
+        return;
+      }
+      // For new users where we've never set the App Home,
+      // the App Home event won't send a `view` property
+      await reloadAppHome(client, event.user, body.team_id, '');
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error);


### PR DESCRIPTION
###  Summary

App Home code was assuming the presence of a `view` property in the `app_home_opened` event payload, which isn't the case for a new user.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/tasks-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).