### PR TITLE
Simplify the listener registration

### DIFF
--- a/nodejs/app.js
+++ b/nodejs/app.js
@@ -6,15 +6,9 @@ const { Sequelize } = require('sequelize');
 
 const sequelize = new Sequelize(process.env.DB_URI);
 
-const {
-  shortcutsListener,
-  viewsListener,
-  eventsListener,
-  actionsListener,
-} = require('./listeners');
+const { registerListeners } = require('./listeners');
 
 let logLevel;
-
 switch (process.env.LOG_LEVEL) {
   case 'debug':
     logLevel = LogLevel.DEBUG;
@@ -39,20 +33,7 @@ const app = new App({
   appToken: process.env.SLACK_APP_TOKEN,
   logLevel,
 });
-
-shortcutsListener.globalNewTask(app);
-shortcutsListener.messageNewTask(app);
-
-viewsListener.newTaskModal(app);
-
-eventsListener.appHomeOpened(app);
-
-actionsListener.blockOpenTaskCheckboxClicked(app);
-actionsListener.blockCreateATaskAppHome(app);
-actionsListener.blockAppHomeNavOpen(app);
-actionsListener.blockAppHomeNavCompleted(app);
-actionsListener.blockReopenTask(app);
-actionsListener.blockButtonMarkAsDone(app);
+registerListeners(app);
 
 (async () => {
   try {

--- a/nodejs/listeners/actions/index.js
+++ b/nodejs/listeners/actions/index.js
@@ -1,54 +1,28 @@
-const {
-  appHomeNavCompletedCallback,
-} = require('./block_app-home-nav-completed');
-
-const {
-  appHomeNavCreateATaskCallback,
-} = require('./block_app-home-nav-create-a-task');
-
+const { appHomeNavCompletedCallback } = require('./block_app-home-nav-completed');
+const { appHomeNavCreateATaskCallback } = require('./block_app-home-nav-create-a-task');
 const { appHomeNavOpenCallback } = require('./block_app-home-nav-open');
-
 const { buttonMarkAsDoneCallback } = require('./block_button-mark-as-done');
-
 const { reopenTaskCallback } = require('./block_reopen-task');
+const { openTaskCheckboxClickedCallback } = require('./block_open_task_list_home');
 
-const {
-  openTaskCheckboxClickedCallback,
-} = require('./block_open_task_list_home');
-
-const blockAppHomeNavCompletedListener = (app) => {
+module.exports.register = (app) => {
   app.action(
     { action_id: 'app-home-nav-completed', type: 'block_actions' },
     appHomeNavCompletedCallback,
   );
-};
-
-const blockCreateATaskAppHomeListener = (app) => {
   app.action('app-home-nav-create-a-task', appHomeNavCreateATaskCallback);
-};
-
-const blockAppHomeNavOpenListener = (app) => {
   app.action(
     { action_id: 'app-home-nav-open', type: 'block_actions' },
     appHomeNavOpenCallback,
   );
-};
-
-const blockButtonMarkAsDoneListener = (app) => {
   app.action(
     { action_id: 'button-mark-as-done', type: 'block_actions' },
     buttonMarkAsDoneCallback,
   );
-};
-
-const blockReopenTaskListener = (app) => {
   app.action(
     { action_id: 'reopen-task', type: 'block_actions' },
     reopenTaskCallback,
   );
-};
-
-const blockOpenTaskCheckboxClickedListener = (app) => {
   app.action(
     {
       action_id: 'blockOpenTaskCheckboxClicked',
@@ -56,13 +30,4 @@ const blockOpenTaskCheckboxClickedListener = (app) => {
     },
     openTaskCheckboxClickedCallback,
   );
-};
-
-module.exports = {
-  blockOpenTaskCheckboxClicked: blockOpenTaskCheckboxClickedListener,
-  blockCreateATaskAppHome: blockCreateATaskAppHomeListener,
-  blockAppHomeNavOpen: blockAppHomeNavOpenListener,
-  blockAppHomeNavCompleted: blockAppHomeNavCompletedListener,
-  blockReopenTask: blockReopenTaskListener,
-  blockButtonMarkAsDone: blockButtonMarkAsDoneListener,
 };

--- a/nodejs/listeners/events/index.js
+++ b/nodejs/listeners/events/index.js
@@ -1,8 +1,5 @@
 const { appHomeOpenedCallback } = require('./app_home_opened');
 
-const appHomeOpenedListener = (app) =>
+module.exports.register = (app) => {
   app.event('app_home_opened', appHomeOpenedCallback);
-
-module.exports = {
-  appHomeOpened: appHomeOpenedListener,
 };

--- a/nodejs/listeners/index.js
+++ b/nodejs/listeners/index.js
@@ -3,9 +3,9 @@ const viewsListener = require('./views');
 const eventsListener = require('./events');
 const actionsListener = require('./actions');
 
-module.exports = {
-  shortcutsListener,
-  viewsListener,
-  eventsListener,
-  actionsListener,
+module.exports.registerListeners = (app) => {
+  shortcutsListener.register(app);
+  viewsListener.register(app);
+  eventsListener.register(app);
+  actionsListener.register(app);
 };

--- a/nodejs/listeners/shortcuts/index.js
+++ b/nodejs/listeners/shortcuts/index.js
@@ -1,13 +1,7 @@
 const { messageNewTaskCallback } = require('./message-new-task');
 const { globalNewTaskCallback } = require('./global-new-task');
 
-const messageNewTaskListener = (app) =>
+module.exports.register = (app) => {
   app.shortcut('message_new_task', messageNewTaskCallback);
-
-const globalNewTaskListener = (app) =>
   app.shortcut('global_new_task', globalNewTaskCallback);
-
-module.exports = {
-  globalNewTask: globalNewTaskListener,
-  messageNewTask: messageNewTaskListener,
 };

--- a/nodejs/listeners/views/index.js
+++ b/nodejs/listeners/views/index.js
@@ -1,8 +1,5 @@
 const { newTaskModalCallback } = require('./new-task-modal');
 
-const newTaskModalListener = (app) =>
+module.exports.register = (app) => {
   app.view('new-task-modal', newTaskModalCallback);
-
-module.exports = {
-  newTaskModal: newTaskModalListener,
 };


### PR DESCRIPTION
###  Summary

As we discussed at https://github.com/slackapi/tasks-app/issues/83, we can simplify the listener function management.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/tasks-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).